### PR TITLE
branches/deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The size determins how long the sound will last. Larger circles will sound out f
 
 There are also a few parameters to adjust under the _KEY 1_ parameters page. Play around with those.
 
+### v1.2
+Added deterministic burst type option. This should allow for more loop like rhythms.
+
 ### v1.1
 Added crow support.
 

--- a/circles.lua
+++ b/circles.lua
@@ -128,6 +128,11 @@ function setupParams()
       libc.shouldBurstOnScreenEdge = true
     end
   end)
+  
+  params:add_option("burst type", "burst type", { "random", "deterministic"})
+  params:set_action("burst type", function(value)
+    libc.burst_type = value
+  end)
 end
 
 function init()

--- a/lib/libCircles.lua
+++ b/lib/libCircles.lua
@@ -18,6 +18,7 @@ local libCircles = {}
 
 libCircles.p = {}
 libCircles.shouldBurstOnScreenEdge = false
+libCircles.burst_type = 1 -- 1 = random, 2 = deterministic
 libCircles.screen_width = 128
 libCircles.screen_height = 64
 
@@ -131,11 +132,19 @@ function libCircles._detectCollisions()
         if libCircles._isCircleTooBig(c2) then
           circlesToBurst[c2] = true
         elseif libCircles._areCirclesTouching(c1, c2) then
-          -- randomly pick one to burst
-          if math.random(2) == 1 then
-            circlesToBurst[c1] = true
-          else
-            circlesToBurst[c2] = true
+	  if libCircles.burst_type == 1 then
+            -- randomly pick one to burst
+            if math.random(2) == 1 then
+              circlesToBurst[c1] = true
+            else
+              circlesToBurst[c2] = true
+            end
+	  elseif libCircles.burst_type == 2 then
+	    if c1.r > c2.r then
+	      circlesToBurst[c1] = true
+	    else
+	      circlesToBurst[c2] = true
+	    end
           end
         end
       end 

--- a/lib/libCircles.lua
+++ b/lib/libCircles.lua
@@ -14,13 +14,14 @@
 --   updateCircles() - increments each circle's size and runs collision detection
 --   updateCursor(dx, dy) - updates p with the given x, y deltas
 
-local burst_types = { random = 1, deterministic = 2 }
+math.randomseed(os.time())
 
 local libCircles = {}
 
 libCircles.p = {}
+libCircles.burst_types = { random = 1, deterministic = 2 }
 libCircles.shouldBurstOnScreenEdge = false
-libCircles.burst_type = burst_types.random
+libCircles.burst_type = libCircles.burst_types.random
 libCircles.screen_width = 128
 libCircles.screen_height = 64
 
@@ -133,14 +134,13 @@ function libCircles._detectCollisions()
         if libCircles._isCircleTooBig(c2) then
           circlesToBurst[c2] = true
         elseif libCircles._areCirclesTouching(c1, c2) then
-          if libCircles.burst_type == burst_types.random then
-            -- randomly pick one to burst
-            if math.random(2) == 1 then
+          if libCircles.burst_type == libCircles.burst_types.random then
+            if math.random(2) == 1 and circlesToBurst[c1] ~= true then
               circlesToBurst[c1] = true
             else
               circlesToBurst[c2] = true
             end
-          elseif libCircles.burst_type == burst_types.deterministic then
+          elseif libCircles.burst_type == libCircles.burst_types.deterministic then
             if c1.r > c2.r then
               circlesToBurst[c1] = true
             else

--- a/lib/libCircles.lua
+++ b/lib/libCircles.lua
@@ -14,11 +14,13 @@
 --   updateCircles() - increments each circle's size and runs collision detection
 --   updateCursor(dx, dy) - updates p with the given x, y deltas
 
+local burst_types = { random = 1, deterministic = 2 }
+
 local libCircles = {}
 
 libCircles.p = {}
 libCircles.shouldBurstOnScreenEdge = false
-libCircles.burst_type = 1 -- 1 = random, 2 = deterministic
+libCircles.burst_type = burst_types.random
 libCircles.screen_width = 128
 libCircles.screen_height = 64
 
@@ -41,14 +43,13 @@ function libCircles.addCircle(x, y)
   x = x or libCircles.p.x
   y = y or libCircles.p.y
   
-	local c = {}
-	c.x = x
-	c.y = y
-	c.r = 1
-	
-	table.insert(libCircles._circles, c)
-		
-	return #libCircles._circles
+  local c = {}
+  c.x = x
+  c.y = y
+  c.r = 1
+  table.insert(libCircles._circles, c)
+  
+  return #libCircles._circles
 end	
 
 --- removes the circle at the given index
@@ -56,7 +57,7 @@ end
 function libCircles.removeCircle(index)
   index = index or #libCircles._circles
   
-	table.remove(libCircles._circles, index)
+  table.remove(libCircles._circles, index)
 end
 
 -- removes the first circle found that contains p
@@ -85,14 +86,14 @@ function libCircles.forEachCircle(handler)
     for i=1,#libCircles._circles do
       local c = libCircles._circles[i]
       handler(c)
-	  end
-	end
+    end
+  end
 end
 
 --- updates the circles and performs collision detection
 function libCircles.updateCircles()
   libCircles._growCircles()
-	local circlesToBurst = libCircles._detectCollisions()
+  local circlesToBurst = libCircles._detectCollisions()
   for k,v in pairs(circlesToBurst) do
     libCircles._notifyOfCircleBurst(k)
     k.r = 1
@@ -112,10 +113,10 @@ Private Helpers
 --]]
 
 function libCircles._growCircles()
-	for i=1,#libCircles._circles do
-		local c = libCircles._circles[i]
-		c.r = c.r + 1
-	end	
+  for i=1,#libCircles._circles do
+    local c = libCircles._circles[i]
+    c.r = c.r + 1
+  end	
 end
 
 function libCircles._detectCollisions()
@@ -132,19 +133,19 @@ function libCircles._detectCollisions()
         if libCircles._isCircleTooBig(c2) then
           circlesToBurst[c2] = true
         elseif libCircles._areCirclesTouching(c1, c2) then
-	  if libCircles.burst_type == 1 then
+          if libCircles.burst_type == burst_types.random then
             -- randomly pick one to burst
             if math.random(2) == 1 then
               circlesToBurst[c1] = true
             else
               circlesToBurst[c2] = true
             end
-	  elseif libCircles.burst_type == 2 then
-	    if c1.r > c2.r then
-	      circlesToBurst[c1] = true
-	    else
-	      circlesToBurst[c2] = true
-	    end
+          elseif libCircles.burst_type == burst_types.deterministic then
+            if c1.r > c2.r then
+              circlesToBurst[c1] = true
+            else
+              circlesToBurst[c2] = true
+            end
           end
         end
       end 
@@ -174,16 +175,16 @@ function libCircles._isCircleTooBig(c)
 end
 
 function libCircles._areCirclesTouching(c1, c2)
-	local distSq = (c1.x - c2.x) * (c1.x - c2.x) + (c1.y - c2.y) * (c1.y - c2.y)
-	local radSumSq = (c1.r + c2.r) * (c1.r + c2.r)
-	
-	if distSq == radSumSq then
-	  return true
-	elseif distSq > radSumSq then
-		return false
-	else
-		return true
-	end
+  local distSq = (c1.x - c2.x) * (c1.x - c2.x) + (c1.y - c2.y) * (c1.y - c2.y)
+  local radSumSq = (c1.r + c2.r) * (c1.r + c2.r)
+  
+  if distSq == radSumSq then
+    return true
+  elseif distSq > radSumSq then
+    return false
+  else
+    return true
+  end
 end
 
 function libCircles._isPointInCircle(p, c)

--- a/lib/libCirclesTest.lua
+++ b/lib/libCirclesTest.lua
@@ -52,8 +52,8 @@ assert(libc._circles[2].r == 4)
 -- a random circle will burst. we don't know which one. assert that only 1 of them has burst.
 local burstCount = 0
 libc.handleCircleBurst = function(circle)
-    assert(circle.r == 5)
-    burstCount = burstCount + 1
+  assert(circle.r == 5)
+  burstCount = burstCount + 1
 end
 libc.updateCircles()
 assert((libc._circles[1].r == 1 and libc._circles[2].r == 5) or (libc._circles[1].r == 5 and libc._circles[2].r == 1))
@@ -77,8 +77,8 @@ libc.updateCircles()
 libc.updateCircles()
 burstCount = 0
 libc.handleCircleBurst = function(circle)
-    assert(circle.r == 5)
-    burstCount = burstCount + 1
+  assert(circle.r == 5)
+  burstCount = burstCount + 1
 end
 libc.updateCircles()
 assert(libc._circles[1].r == 1 and libc._circles[2].r == 4)
@@ -109,7 +109,7 @@ libc.updateCircles()
 libc.updateCircles()
 libc.updateCircles()
 libc.forEachCircle(function(c)
-    assert(c.r == 4)
+  assert(c.r == 4)
 end)
 
 -- ensure that at least 2 of them burst

--- a/lib/libCirclesTest.lua
+++ b/lib/libCirclesTest.lua
@@ -1,4 +1,5 @@
-local libc = dofile('/Users/jake/Code/norns/circles/lib/libCircles.lua')
+--local libc = dofile('/Users/jake/Code/norns/circles/lib/libCircles.lua')
+local libc = dofile('/home/we/dust/code/carter/circles/lib/libCircles.lua')
 
 -- test default values
 assert(libc ~= nil)
@@ -33,6 +34,7 @@ assert(#libc._circles == 0)
 assert(libc.handleCircleBurst == nil)
 
 -- test burst
+libc.burst_type = 1
 libc.p.x = 30
 libc.addCircle()
 libc.p.x = 40
@@ -57,6 +59,32 @@ libc.updateCircles()
 assert((libc._circles[1].r == 1 and libc._circles[2].r == 5) or (libc._circles[1].r == 5 and libc._circles[2].r == 1))
 assert(burstCount == 1)
 libc.reset()
+
+-- test deterministic burst. bigger bubble should burst
+libc.burst_type = 2
+assert(#libc._circles == 0)
+libc.p.x = 30
+libc.addCircle()
+libc.updateCircles()
+libc.p.x = 40
+libc.addCircle()
+assert(#libc._circles == 2)
+assert(libc._circles[1].r == 2)
+assert(libc._circles[2].r == 1)
+
+libc.updateCircles()
+libc.updateCircles()
+libc.updateCircles()
+burstCount = 0
+libc.handleCircleBurst = function(circle)
+    assert(circle.r == 5)
+    burstCount = burstCount + 1
+end
+libc.updateCircles()
+assert(libc._circles[1].r == 1 and libc._circles[2].r == 4)
+assert(burstCount == 1)
+libc.reset()
+libc.burst_type = 1
 
 -- test keeping cursor on screen: lower bound
 libc.p.x = 0

--- a/lib/libCirclesTest.lua
+++ b/lib/libCirclesTest.lua
@@ -1,5 +1,5 @@
---local libc = dofile('/Users/jake/Code/norns/circles/lib/libCircles.lua')
-local libc = dofile('/home/we/dust/code/carter/circles/lib/libCircles.lua')
+local libc = dofile('/Users/jake/Code/norns/circles/lib/libCircles.lua')
+--local libc = dofile('/home/we/dust/code/carter/circles/lib/libCircles.lua')
 
 -- test default values
 assert(libc ~= nil)
@@ -61,13 +61,11 @@ assert(burstCount == 1)
 libc.reset()
 
 -- test deterministic burst. bigger bubble should burst
-libc.burst_type = 2
+libc.burst_type = libc.burst_types.deterministic
 assert(#libc._circles == 0)
-libc.p.x = 30
-libc.addCircle()
+local c1Index = libc.addCircle(30, 0)
 libc.updateCircles()
-libc.p.x = 40
-libc.addCircle()
+libc.addCircle(40, 0)
 assert(#libc._circles == 2)
 assert(libc._circles[1].r == 2)
 assert(libc._circles[2].r == 1)
@@ -77,14 +75,15 @@ libc.updateCircles()
 libc.updateCircles()
 burstCount = 0
 libc.handleCircleBurst = function(circle)
-  assert(circle.r == 5)
+  assert(circle == libc._circles[c1Index])
+  assert(circle.r == 6)
   burstCount = burstCount + 1
 end
 libc.updateCircles()
-assert(libc._circles[1].r == 1 and libc._circles[2].r == 4)
+assert(libc._circles[1].r == 1 and libc._circles[2].r == 5)
 assert(burstCount == 1)
 libc.reset()
-libc.burst_type = 1
+libc.burst_type = libc.burst_types.random
 
 -- test keeping cursor on screen: lower bound
 libc.p.x = 0
@@ -118,7 +117,7 @@ libc.handleCircleBurst = function(circle)
   burstCount = burstCount + 1
 end
 libc.updateCircles()
-assert(burstCount == 2)
+assert(burstCount == 2, "expected burstCount of 2 but got " .. burstCount)
 libc.reset()
 
 -- test remove circle at


### PR DESCRIPTION
Added deterministic burst type option.
Cleaned up a bunch of white space issues.
Fixed random burst dealing with more than two collisions found by setting the random seed to `os.time()`.
