### PR TITLE
branches/params

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The size determins how long the sound will last. Larger circles will sound out f
 
 There are also a few parameters to adjust under the _KEY 1_ parameters page. Play around with those.
 
+### v1.3
+Circles now supports the system saving/loading of params. See the PARAMETERS section of https://monome.org/docs/norns/ for more information.
+
 ### v1.2
 Added deterministic burst type option. This should allow for more loop like rhythms.
 

--- a/circles.lua
+++ b/circles.lua
@@ -1,5 +1,5 @@
 -- oO ( circles ) Oo
--- v1.2 @jakecarter
+-- v1.3 @jakecarter
 -- llllllll.co/t/22951
 -- 
 -- ENC 2 & 3 move cursor
@@ -16,6 +16,10 @@
 -- Enjoy
 --
 -- Release Notes
+-- v1.3
+-- System param saving/loading
+-- now supported.
+--
 -- v1.2
 -- Added param for determinsitc
 -- burst type.


### PR DESCRIPTION
Remove conditional hiding/showing of irrelevant params.
Fix collision with `beatclock`'s 'clock' param.
