### PR TITLE
Fix setting midi out channel

### DIFF
--- a/circles.lua
+++ b/circles.lua
@@ -77,7 +77,7 @@ function setupParams()
     min = 1, max = 16, default = 1,
     action = function(value)
       -- JCTODO: Turn all notes off
-      midi_channel = value
+      midi_out_channel = value
     end
   })
   


### PR DESCRIPTION
The variable set here didn't match with the one read elsewhere. As a result, the script was always sending notes on midi channel 1.